### PR TITLE
ログイン・新規登録画面作成/ログアウト導線設置

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,4 +324,4 @@ UI・体験の改善：
 
 ## ER図
 
-- ![alt text](../ER.png)
+- ![ER図](ER.png)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+    before_action :authenticate_user!
+
+    def after_sign_in_path_for(resource)
+        root_path
+    end
+
+    def after_sign_out_path_for(resource_or_scope)
+        root_path
+    end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:top]
+  
   def top; end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,49 @@
+<div class="min-h-screen flex flex-col items-center justify-center px-5 py-16 bg-cream">
+
+  <%# ロゴテキスト %>
+  <p class="font-nunito text-4xl font-black tracking-tight text-text-main mb-3">
+    新規登録
+  </p>
+
+  <%# サブタイトル %>
+  <p class="font-dm text-sm text-text-muted mb-10">
+    アカウントを作成してはじめよう
+  </p>
+
+  <%# フォーム %>
+  <div class="w-full max-w-xs">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <div class="flex flex-col gap-4 mb-6">
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block font-dm text-sm text-text-main mb-1" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+              class: "w-full px-4 py-3 rounded-2xl border-2 border-gold/30 bg-cream text-text-main font-dm text-sm focus:outline-none focus:border-gold transition-colors" %>
+        </div>
+
+        <div>
+          <%= f.label :password, "パスワード", class: "block font-dm text-sm text-text-main mb-1" %>
+          <%= f.password_field :password, autocomplete: "new-password",
+              class: "w-full px-4 py-3 rounded-2xl border-2 border-gold/30 bg-cream text-text-main font-dm text-sm focus:outline-none focus:border-gold transition-colors" %>
+          <% if @minimum_password_length %>
+            <p class="font-dm text-xs text-text-muted mt-1"><%= @minimum_password_length %>文字以上</p>
+          <% end %>
+        </div>
+
+        <div>
+          <%= f.label :password_confirmation, "パスワード確認", class: "block font-dm text-sm text-text-main mb-1" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password",
+              class: "w-full px-4 py-3 rounded-2xl border-2 border-gold/30 bg-cream text-text-main font-dm text-sm focus:outline-none focus:border-gold transition-colors" %>
+        </div>
+      </div>
+
+      <%= f.submit "新規登録",
+          class: "block w-full py-4 rounded-2xl bg-brown text-white font-nunito text-lg font-extrabold text-center cursor-pointer hover:bg-brown-mid transition-colors" %>
+    <% end %>
+
+    <div class="mt-6 text-center">
+      <%= link_to "すでにアカウントをお持ちの方はこちら", new_session_path(resource_name),
+          class: "font-dm text-xs text-text-muted opacity-45" %>
+    </div>
+  </div>
+
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,45 @@
+<div class="min-h-screen flex flex-col items-center justify-center px-5 py-16 bg-cream">
+
+  <%# タイトル %>
+  <p class="font-nunito text-4xl font-black tracking-tight text-text-main mb-3">
+    ログイン
+  </p>
+
+  <%# サブタイトル %>
+  <p class="font-dm text-sm text-text-muted mb-10">
+    ログインしてパッキングを始めよう
+  </p>
+
+  <%# フォームカード %>
+  <div class="w-full max-w-xs">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="flex flex-col gap-4 mb-6">
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block font-dm text-sm text-text-main mb-1" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+              class: "w-full px-4 py-3 rounded-2xl border-2 border-gold/30 bg-cream text-text-main font-dm text-sm focus:outline-none focus:border-gold transition-colors" %>
+        </div>
+
+        <div>
+          <%= f.label :password, "パスワード", class: "block font-dm text-sm text-text-main mb-1" %>
+          <%= f.password_field :password, autocomplete: "current-password",
+              class: "w-full px-4 py-3 rounded-2xl border-2 border-gold/30 bg-cream text-text-main font-dm text-sm focus:outline-none focus:border-gold transition-colors" %>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <%= f.check_box :remember_me, class: "rounded border-gold/30" %>
+          <%= f.label :remember_me, "ログイン状態を保持する", class: "font-dm text-sm text-text-muted" %>
+        </div>
+      </div>
+
+      <%= f.submit "ログイン",
+          class: "block w-full py-4 rounded-2xl border-2 border-gold text-gold font-nunito text-lg font-extrabold text-center cursor-pointer hover:bg-gold/10 transition-colors" %>
+    <% end %>
+
+    <div class="mt-6 text-center">
+      <%= link_to "アカウントをお持ちでない方はこちら", new_registration_path(resource_name),
+          class: "font-dm text-xs text-text-muted opacity-45" %>
+    </div>
+  </div>
+
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,18 @@
     <% if alert %>
       <div class="flash-alert"><%= alert %></div>
     <% end %>
+
+    <%# ナビゲーションバー %>
+  <% if user_signed_in? %>
+    <nav class="flex items-center justify-between px-5 py-3 bg-cream border-b border-gold/20">
+      <%= link_to "PackReady", root_path,
+          class: "font-nunito font-black text-lg text-text-main" %>
+      <%= link_to "ログアウト", destroy_user_session_path,
+          data: { turbo_method: :delete },
+          class: "font-dm text-sm text-text-muted opacity-45 hover:opacity-100 transition-colors" %>
+    </nav>
+  <% end %>
+  
     <%= yield %>
   </body>
 </html>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -25,9 +25,9 @@
 
   <%# ボタングループ %>
   <div class="flex flex-col gap-4 w-full max-w-xs mb-10">
-    <%= link_to "新規登録", "#",
+    <%= link_to "新規登録", new_user_registration_path,
           class: "block w-full py-4 rounded-2xl bg-brown text-white font-nunito text-lg font-extrabold text-center hover:bg-brown-mid transition-colors" %>
-    <%= link_to "ログイン", "#",
+    <%= link_to "ログイン", new_user_session_path,
           class: "block w-full py-4 rounded-2xl border-2 border-gold text-gold font-nunito text-lg font-extrabold text-center hover:bg-gold/10 transition-colors" %>
   </div>
 


### PR DESCRIPTION
## 概要
ログイン・新規登録画面を作成、ログアウト導線とアクセス制御を実装した。

## 作業内容
- devise/sessions/new.html.erb を作成・編集
- devise/registrations/new.html.erb を作成・編集
- application.html.erb にナビゲーションバーを追加（表示位置は後で調整）
- application_controller.rb に before_action :authenticate_user! を追加
- static_pages_controller.rb で top アクションのみ認証をスキップ
- トップ画面の新規登録・ログインボタンのリンク先を設定

### 補足
ナビバーの表示範囲はリスト一覧画面実装時に調整予定

## 動作確認
- ログイン・新規登録・ログアウトが一通り動作する

close #8 