### PR TITLE
リスト一覧表示機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
     before_action :authenticate_user!
 
     def after_sign_in_path_for(resource)
-        root_path
+        packing_lists_path
     end
 
     def after_sign_out_path_for(resource_or_scope)

--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -1,4 +1,8 @@
 class PackingListsController < ApplicationController
+  def index
+    @packing_lists = current_user.packing_lists.order(departure_date: :asc)
+  end
+
   def new
     @packing_list = current_user.packing_lists.build
   end
@@ -10,6 +14,10 @@ class PackingListsController < ApplicationController
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def show
+    @packing_list = current_user.packing_lists.find(params[:id])
   end
 
   private

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -1,0 +1,43 @@
+<div class="min-h-screen bg-cream">
+  <div class="max-w-lg mx-auto px-6 py-8">
+
+    <%# ヘッダー %>
+    <div class="relative flex items-center justify-center mb-8">
+      <h1 class="text-3xl font-bold text-brown font-nunito">リスト一覧</h1>
+    </div>
+
+    <%# リスト一覧 %>
+    <% if @packing_lists.empty? %>
+      <p class="text-center text-gray-400 mt-20">リストがありません</p>
+    <% else %>
+      <div class="space-y-3">
+        <% @packing_lists.each do |list| %>
+          <%= link_to packing_list_path(list), class: "block" do %>
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 relative">
+
+              <%# ︙ボタン %>
+              <button class="absolute top-3 right-3 text-gray-400 text-xl leading-none">⋮</button>
+
+              <h2 class="text-lg font-bold text-brown font-nunito pr-6"><%= list.name %></h2>
+
+              <% if list.departure_date.present? %>
+                <p class="text-sm text-gray-500 mt-1">
+                  出発日：<%= list.departure_date.strftime("%Y/%m/%d") %>
+                </p>
+              <% end %>
+
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+
+  </div>
+
+  <%# 新規作成ボタン（FAB）- 右下固定 %>
+  <%= link_to new_packing_list_path,
+      class: "fixed bottom-6 right-6 w-14 h-14 bg-gold rounded-full shadow-lg flex items-center justify-center text-white text-3xl font-light" do %>
+    +
+  <% end %>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
   root "static_pages#top"
-  resources :packing_lists, only: [:new, :create]
+  resources :packing_lists, only: [:index, :new, :create, :show]
   # Defines the root path route ("/")
   # root "posts#index"
 end


### PR DESCRIPTION
## 概要
ログインユーザーが自分のパッキングリストを一覧で確認できる機能を実装した。

## 実装内容
- `PackingListsController` に `index` アクションを追加
- `current_user.packing_lists` 経由で取得することで、ログインユーザー自身のリストのみ表示されるよう実装
- リスト一覧画面のビューを作成
  - カード形式でリスト名・出発日を表示
  - リストが0件の場合は「リストがありません」を表示
  - 右下のFABボタンから新規作成画面へ遷移
  - カードタップでリスト詳細画面へ遷移（詳細画面は別ISSUEで実装予定）
  - ︙ボタンをカード右上に配置（メニュー動作は別ISSUEで実装予定）
- ログイン・新規登録後のリダイレクト先をリスト一覧画面（`packing_lists_path`）に変更

## 動作確認
- 自分のリストのみ一覧に表示される
- リストが0件のとき「リストがありません」が表示される
- FABボタンから新規作成画面へ遷移できる
- 新規登録・ログイン後にリスト一覧画面へ遷移する
- ログアウト後はトップページへ遷移する

## 備考
- `show` ルートを追加済み（詳細画面の実装は別ISSUEで対応）
- カードのリンク先（`packing_list_path`）は現時点では未実装のため、タップするとエラーになる

close #10 