### PR TITLE
リスト詳細画面

### DIFF
--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -1,4 +1,6 @@
 class PackingListsController < ApplicationController
+  before_action :set_packing_list, only: [:show]
+  
   def index
     @packing_lists = current_user.packing_lists.order(departure_date: :asc)
   end
@@ -17,10 +19,15 @@ class PackingListsController < ApplicationController
   end
 
   def show
-    @packing_list = current_user.packing_lists.find(params[:id])
   end
 
   private
+
+  def set_packing_list
+    @packing_list = current_user.packing_lists.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render file: "#{Rails.root}/public/404.html", status: :not_found, layout: false
+  end
 
   def packing_list_params
     params.require(:packing_list).permit(:name, :departure_date, :notification_time)

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -1,0 +1,37 @@
+<div class="max-w-lg mx-auto px-6 py-8">
+
+  <%# ヘッダー：戻る／リスト名（中央）／編集ボタン %>
+  <div class="relative flex items-center justify-center mb-6">
+    <%= link_to packing_lists_path, class: "absolute left-0 text-brown" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+    <% end %>
+
+    <h1 class="text-2xl font-bold text-brown"><%= @packing_list.name %></h1>
+
+    <button class="absolute right-0 text-sm text-gold font-semibold" disabled>編集</button>
+  </div>
+
+  <%# 出発日 %>
+  <div class="text-center text-sm text-brown/60 mb-8">
+    <% if @packing_list.departure_date %>
+      出発日：<%= @packing_list.departure_date.strftime("%Y年%m月%d日") %>
+    <% else %>
+      出発日未設定
+    <% end %>
+  </div>
+
+  <%# 当日セクション（上部） %>
+  <section class="mb-8">
+    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日の朝</h2>
+    <p class="text-sm text-brown/40">アイテムはまだありません</p>
+  </section>
+
+  <%# 前日セクション（下部） %>
+  <section class="mb-8">
+    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">前日まで</h2>
+    <p class="text-sm text-brown/40">アイテムはまだありません</p>
+  </section>
+
+</div>


### PR DESCRIPTION
## 概要
リスト詳細画面の実装をした

## 変更内容
- PackingListsControllerにbefore_action :set_packing_listを追加
- 他ユーザーのリストIDを直打ちした場合に404を返す処理を実装
- app/views/packing_lists/show.html.erbを新規作成
- ヘッダー：戻るボタン／リスト名／編集ボタンの構成
- 出発日を表示（未設定の場合は「出発日未設定」と表示）
- アイテムセクションを当日／前日に分けて表示（当日を上部に配置）

## 未実装（別ISSUEで対応予定）
- アイテム一覧（itemsテーブル未実装のため空表示）
- 進捗表示（同上）
- 編集ボタンの動作

## 動作確認
- 自分のリストの詳細画面が表示される
- 戻るボタンで一覧画面に戻る
- リスト名・出発日が正しく表示される

close #38 