### PR TITLE
アイテム追加機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,4 +324,4 @@ UI・体験の改善：
 
 ## ER図
 
-- ![ER図](<img width="1336" height="376" alt="Image" src="https://github.com/user-attachments/assets/45fac644-9e30-4aa7-a267-3f6b72b517db" />)
+- (<img width="1336" height="376" alt="Image" src="https://github.com/user-attachments/assets/45fac644-9e30-4aa7-a267-3f6b72b517db" />)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,29 @@
+class ItemsController < ApplicationController
+  before_action :set_packing_list
+
+  def new
+    @item = @packing_list.items.build
+    @item.timing = params[:timing] if params[:timing].present?
+  end
+
+  def create
+    @item = @packing_list.items.build(item_params)
+    if @item.save
+      redirect_to edit_packing_list_path(@packing_list), notice: "アイテムを追加しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_packing_list
+    @packing_list = current_user.packing_lists.find(params[:packing_list_id])
+  rescue ActiveRecord::RecordNotFound
+    render file: "#{Rails.root}/public/404.html", status: :not_found, layout: false
+  end
+
+  def item_params
+    params.require(:item).permit(:name, :timing)
+  end
+end

--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -21,6 +21,10 @@ class PackingListsController < ApplicationController
   def show
   end
 
+  def edit
+    @packing_list = current_user.packing_lists.find(params[:id])
+  end
+
   private
 
   def set_packing_list

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,8 @@
+class Item < ApplicationRecord
+  belongs_to :packing_list
+
+  enum timing: { morning: 0, day_before: 1 }
+
+  validates :name, presence: true
+  validates :timing, presence: true
+end

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -2,4 +2,5 @@ class PackingList < ApplicationRecord
   validates :name, presence: true
   
   belongs_to :user
+  has_many :items, dependent: :destroy
 end

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,0 +1,32 @@
+<div class="max-w-lg mx-auto px-6 py-8">
+  <div class="relative flex items-center justify-center mb-6">
+    <%= link_to "←", edit_packing_list_path(@packing_list), class: "absolute left-0 text-brown text-xl" %>
+    <h1 class="text-2xl font-bold text-brown">アイテムを追加</h1>
+  </div>
+
+  <p class="text-center text-sm text-brown/60 mb-6">
+    タイミング：<%= @item.morning? ? "当日の朝" : "前日まで" %>
+  </p>
+
+  <%= form_with model: [@packing_list, @item], data: { turbo: false } do |f| %>
+    <% if @item.errors.any? %>
+      <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-600">
+        <% @item.errors.full_messages.each do |msg| %>
+          <p><%= msg %></p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%= f.hidden_field :timing %>
+
+    <div class="mb-6">
+      <%= f.label :name, "持ち物名", class: "block text-sm font-semibold text-brown mb-1" %>
+      <%= f.text_field :name,
+          placeholder: "例：パスポート",
+          class: "w-full border border-brown/30 rounded-lg px-4 py-2 text-brown bg-cream focus:outline-none focus:ring-2 focus:ring-gold/50" %>
+    </div>
+
+    <%= f.submit "追加する",
+        class: "w-full bg-brown text-cream font-bold py-3 rounded-xl hover:opacity-80 transition" %>
+  <% end %>
+</div>

--- a/app/views/packing_lists/edit.html.erb
+++ b/app/views/packing_lists/edit.html.erb
@@ -1,0 +1,26 @@
+<%# app/views/packing_lists/edit.html.erb %>
+<div class="max-w-lg mx-auto px-6 py-8">
+  <div class="relative flex items-center justify-center mb-6">
+    <%= link_to "←", packing_list_path(@packing_list), class: "absolute left-0 text-brown text-xl" %>
+    <h1 class="text-2xl font-bold text-brown">持ち物を編集</h1>
+  </div>
+
+  <p class="text-sm text-brown/60 mb-1">旅行名：<%= @packing_list.name %></p>
+  <% if @packing_list.departure_date %>
+    <p class="text-sm text-brown/60 mb-6">出発日：<%= @packing_list.departure_date.strftime("%Y年%m月%d日") %></p>
+  <% end %>
+
+  <section class="mb-8">
+    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日</h2>
+    <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+    <%= link_to "+ 持ち物を追加", new_packing_list_item_path(@packing_list, timing: :morning),
+        class: "block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition" %>
+  </section>
+
+  <section class="mb-8">
+    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">前日まで</h2>
+    <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+    <%= link_to "+ 持ち物を追加", new_packing_list_item_path(@packing_list, timing: :day_before),
+        class: "block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition" %>
+  </section>
+</div>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -11,6 +11,8 @@
     <h1 class="text-2xl font-bold text-brown"><%= @packing_list.name %></h1>
 
     <button class="absolute right-0 text-sm text-gold font-semibold" disabled>編集</button>
+    <%= link_to "編集", edit_packing_list_path(@packing_list),
+    class: "absolute right-0 text-sm text-gold font-semibold" %>
   </div>
 
   <%# 出発日 %>
@@ -24,7 +26,7 @@
 
   <%# 当日セクション（上部） %>
   <section class="mb-8">
-    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日の朝</h2>
+    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日</h2>
     <p class="text-sm text-brown/40">アイテムはまだありません</p>
   </section>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
   root "static_pages#top"
-  resources :packing_lists, only: [:index, :new, :create, :show]
+  resources :packing_lists, only: [:index, :new, :create, :show, :edit] do
+    resources :items, only: [:new, :create]
+  end
   # Defines the root path route ("/")
   # root "posts#index"
 end

--- a/db/migrate/20260309211027_create_items.rb
+++ b/db/migrate/20260309211027_create_items.rb
@@ -1,0 +1,12 @@
+class CreateItems < ActiveRecord::Migration[7.1]
+  def change
+    create_table :items do |t|
+      t.references :packing_list, null: false, foreign_key: true
+      t.string :name, null: false
+      t.integer :timing, null: false, default: 0
+      t.boolean :checked, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_03_200626) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_09_211027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "items", force: :cascade do |t|
+    t.bigint "packing_list_id", null: false
+    t.string "name", null: false
+    t.integer "timing", default: 0, null: false
+    t.boolean "checked", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["packing_list_id"], name: "index_items_on_packing_list_id"
+  end
 
   create_table "packing_lists", force: :cascade do |t|
     t.string "name", null: false
@@ -36,5 +46,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_03_200626) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "items", "packing_lists"
   add_foreign_key "packing_lists", "users"
 end


### PR DESCRIPTION
## 概要
パッキングリストに持ち物を追加する機能を実装した。編集画面のセクションごとの追加ボタンからタイミング（当日の朝・前日まで）を指定して保存できる。

## 実装内容
### Itemモデル
- items テーブルを作成（packing_list_id, name, timing, checked）
- enum timing: { morning: 0, day_before: 1 } で定義
- name のバリデーションを設定

### ルーティング
- packing_lists に items をネストして追加

### コントローラー
- set_packing_list で current_user 経由の認可を実装
- create: 保存成功後に編集画面へリダイレクト

### ビュー
- 編集画面（edit.html.erb）を作成し、セクションごとの追加ボタンを追加
- アイテム追加フォーム（items/new.html.erb）を新規作成
- 詳細画面の編集ボタンを編集画面へのリンクに設定

## 動作確認
-  当日セクションから追加 → timing: morning で保存される
-  前日セクションから追加 → timing: day_before で保存される
-  バリデーションエラー時にエラーメッセージが表示される

## 補足
保存したアイテムの一覧表示は別ISSUEにて実装予定。

close #26 