### PR TITLE
タイミング別にセクション分けして表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,4 +324,4 @@ UI・体験の改善：
 
 ## ER図
 
-- (<img width="1336" height="376" alt="Image" src="https://github.com/user-attachments/assets/45fac644-9e30-4aa7-a267-3f6b72b517db" />)
+<img width="1336" height="376" alt="Image" src="https://github.com/user-attachments/assets/45fac644-9e30-4aa7-a267-3f6b72b517db" />

--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -1,5 +1,5 @@
 class PackingListsController < ApplicationController
-  before_action :set_packing_list, only: [:show]
+  before_action :set_packing_list, only: [:show, :edit]
   
   def index
     @packing_lists = current_user.packing_lists.order(departure_date: :asc)
@@ -19,10 +19,13 @@ class PackingListsController < ApplicationController
   end
 
   def show
+    @morning_items = @packing_list.items.where(timing: :morning)
+    @day_before_items = @packing_list.items.where(timing: :day_before)
   end
 
   def edit
-    @packing_list = current_user.packing_lists.find(params[:id])
+      @morning_items = @packing_list.items.where(timing: :morning)
+      @day_before_items = @packing_list.items.where(timing: :day_before)
   end
 
   private

--- a/app/views/packing_lists/edit.html.erb
+++ b/app/views/packing_lists/edit.html.erb
@@ -1,4 +1,3 @@
-<%# app/views/packing_lists/edit.html.erb %>
 <div class="max-w-lg mx-auto px-6 py-8">
   <div class="relative flex items-center justify-center mb-6">
     <%= link_to "←", packing_list_path(@packing_list), class: "absolute left-0 text-brown text-xl" %>
@@ -10,16 +9,38 @@
     <p class="text-sm text-brown/60 mb-6">出発日：<%= @packing_list.departure_date.strftime("%Y年%m月%d日") %></p>
   <% end %>
 
+  <%# 当日セクション %>
   <section class="mb-8">
     <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日</h2>
-    <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+    <% if @morning_items.any? %>
+      <ul class="space-y-2 mb-3">
+        <% @morning_items.each do |item| %>
+          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+            <span class="text-sm text-brown"><%= item.name %></span>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+    <% end %>
     <%= link_to "+ 持ち物を追加", new_packing_list_item_path(@packing_list, timing: :morning),
         class: "block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition" %>
   </section>
 
+  <%# 前日セクション %>
   <section class="mb-8">
     <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">前日まで</h2>
-    <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+    <% if @day_before_items.any? %>
+      <ul class="space-y-2 mb-3">
+        <% @day_before_items.each do |item| %>
+          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+            <span class="text-sm text-brown"><%= item.name %></span>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+    <% end %>
     <%= link_to "+ 持ち物を追加", new_packing_list_item_path(@packing_list, timing: :day_before),
         class: "block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition" %>
   </section>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -1,21 +1,10 @@
 <div class="max-w-lg mx-auto px-6 py-8">
-
-  <%# ヘッダー：戻る／リスト名（中央）／編集ボタン %>
   <div class="relative flex items-center justify-center mb-6">
-    <%= link_to packing_lists_path, class: "absolute left-0 text-brown" do %>
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-      </svg>
-    <% end %>
-
+    <%= link_to "←", packing_lists_path, class: "absolute left-0 text-brown text-xl" %>
     <h1 class="text-2xl font-bold text-brown"><%= @packing_list.name %></h1>
-
-    <button class="absolute right-0 text-sm text-gold font-semibold" disabled>編集</button>
-    <%= link_to "編集", edit_packing_list_path(@packing_list),
-    class: "absolute right-0 text-sm text-gold font-semibold" %>
+    <%= link_to "編集", edit_packing_list_path(@packing_list), class: "absolute right-0 text-sm text-gold font-semibold" %>
   </div>
 
-  <%# 出発日 %>
   <div class="text-center text-sm text-brown/60 mb-8">
     <% if @packing_list.departure_date %>
       出発日：<%= @packing_list.departure_date.strftime("%Y年%m月%d日") %>
@@ -24,16 +13,35 @@
     <% end %>
   </div>
 
-  <%# 当日セクション（上部） %>
+  <%# 当日朝セクション（上に配置） %>
   <section class="mb-8">
-    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日</h2>
-    <p class="text-sm text-brown/40">アイテムはまだありません</p>
+    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日の朝</h2>
+    <% if @morning_items.any? %>
+      <ul class="space-y-2">
+        <% @morning_items.each do |item| %>
+          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+            <span class="text-sm text-brown"><%= item.name %></span>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-brown/40">アイテムはまだありません</p>
+    <% end %>
   </section>
 
-  <%# 前日セクション（下部） %>
+  <%# 前日セクション（下に配置） %>
   <section class="mb-8">
     <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">前日まで</h2>
-    <p class="text-sm text-brown/40">アイテムはまだありません</p>
+    <% if @day_before_items.any? %>
+      <ul class="space-y-2">
+        <% @day_before_items.each do |item| %>
+          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+            <span class="text-sm text-brown"><%= item.name %></span>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-brown/40">アイテムはまだありません</p>
+    <% end %>
   </section>
-
 </div>


### PR DESCRIPTION
## 概要
リスト詳細画面・持ち物編集画面で、持ち物をタイミング別（当日の朝・前日）にセクション分けして表示する機能を実装した。

## 変更内容
- `PackingListsController` の `show`・`edit` アクションにタイミング別のインスタンス変数を追加
- `before_action :set_packing_list` の `only` に `edit` を追加
- `packing_lists/show.html.erb` をタイミング別セクション表示に更新
- `packing_lists/edit.html.erb` にアイテム一覧表示を追加（追加ボタンは既存のまま）

## 動作確認
- 当日朝のアイテムが「当日」セクションに表示される
- 前日のアイテムが「前日まで」セクションに表示される
- アイテムが0件のセクションに「アイテムはまだありません」が表示される
- 編集画面でも同様にセクション別表示が機能する

close #15 