### PR TITLE
リスト作成後の画面遷移先を詳細画面に修正

### DIFF
--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -12,7 +12,7 @@ class PackingListsController < ApplicationController
   def create
     @packing_list = current_user.packing_lists.build(packing_list_params)
     if @packing_list.save
-      redirect_to root_path, notice: "リストを作成しました"
+      redirect_to packing_list_path(@packing_list), notice: "リストを作成しました"
     else
       render :new, status: :unprocessable_entity
     end


### PR DESCRIPTION
## 概要
パッキングリスト作成後のリダイレクト先をトップページから詳細画面に修正した。

## 変更内容
- `PackingListsController#create` の `redirect_to` を `root_path` から `packing_list_path(@packing_list)` に変更

## 動作確認
- リスト作成後に作成したリストの詳細画面に遷移する