### PR TITLE
ItemsControllerにindexを追加し持ち物編集画面を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,11 @@
 class ItemsController < ApplicationController
   before_action :set_packing_list
 
+  def index
+    @morning_items = @packing_list.items.where(timing: :morning)
+    @day_before_items = @packing_list.items.where(timing: :day_before)
+  end
+
   def new
     @item = @packing_list.items.build
     @item.timing = params[:timing] if params[:timing].present?
@@ -9,7 +14,7 @@ class ItemsController < ApplicationController
   def create
     @item = @packing_list.items.build(item_params)
     if @item.save
-      redirect_to edit_packing_list_path(@packing_list), notice: "アイテムを追加しました"
+      redirect_to packing_list_items_path(@packing_list), notice: "アイテムを追加しました"
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,0 +1,45 @@
+<div class="max-w-lg mx-auto px-6 py-8">
+  <div class="relative flex items-center justify-center mb-6">
+    <%= link_to "←", packing_list_path(@packing_list), class: "absolute left-0 text-brown text-xl" %>
+    <h1 class="text-2xl font-bold text-brown">持ち物を編集</h1>
+  </div>
+
+  <p class="text-sm text-brown/60 mb-1">旅行名：<%= @packing_list.name %></p>
+  <% if @packing_list.departure_date %>
+    <p class="text-sm text-brown/60 mb-6">出発日：<%= @packing_list.departure_date.strftime("%Y年%m月%d日") %></p>
+  <% end %>
+
+  <section class="mb-8">
+    <h2 class="text-base font-bold text-gold border-b border-brown/30 pb-1 mb-4">当日</h2>
+    <% if @morning_items.any? %>
+      <ul class="space-y-2 mb-3">
+        <% @morning_items.each do |item| %>
+          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+            <span class="text-sm text-brown"><%= item.name %></span>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+    <% end %>
+    <%= link_to "+ 持ち物を追加", new_packing_list_item_path(@packing_list, timing: :morning),
+        class: "block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition" %>
+  </section>
+
+  <section class="mb-8">
+    <h2 class="text-base font-bold text-gold border-b border-brown/30 pb-1 mb-4">前日</h2>
+    <% if @day_before_items.any? %>
+      <ul class="space-y-2 mb-3">
+        <% @day_before_items.each do |item| %>
+          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+            <span class="text-sm text-brown"><%= item.name %></span>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+    <% end %>
+    <%= link_to "+ 持ち物を追加", new_packing_list_item_path(@packing_list, timing: :day_before),
+        class: "block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition" %>
+  </section>
+</div>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -15,7 +15,7 @@
 
   <%# 当日朝セクション（上に配置） %>
   <section class="mb-8">
-    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日の朝</h2>
+    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日</h2>
     <% if @morning_items.any? %>
       <ul class="space-y-2">
         <% @morning_items.each do |item| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  get 'packing_lists/new'
-  get 'packing_lists/create'
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -8,8 +6,9 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
   root "static_pages#top"
-  resources :packing_lists, only: [:index, :new, :create, :show, :edit] do
-    resources :items, only: [:new, :create]
+
+  resources :packing_lists, only: [:index, :new, :create, :show, :edit, :update] do
+    resources :items, only: [:index, :new, :create]
   end
   # Defines the root path route ("/")
   # root "posts#index"


### PR DESCRIPTION
## 概要
持ち物編集画面をItemsController#indexとして切り出し、専用のビューを実装した。

## 背景
これまでPackingListsController#editにアイテム一覧・追加ボタンが混在していた。
editはリスト自体（名前・出発日）の編集に専念させる設計に変更するため、持ち物編集画面をitems#indexに分離した。

## 変更内容
- ルーティングにitems#indexを追加
- ItemsControllerにindexアクションを追加
- `app/views/items/index.html.erb`を新規作成
- items#createのリダイレクト先をedit_packing_list_pathからpacking_list_items_pathに変更

## 動作確認
- [x] /packing_lists/:id/itemsにアクセスすると持ち物編集画面が表示される
- [x] アイテムを追加するとitems#indexに戻ってくる
- [x] タイミング別にアイテムが正しく表示される