### PR TITLE
チェック切替・保存機能をTurbo Streamで実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def check
+    @item = @packing_list.items.find(params[:id])
+    @item.update!(checked: !@item.checked)
+  end
+
   private
 
   def set_packing_list

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,0 +1,16 @@
+<li id="<%= dom_id(item) %>" class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+  <%= form_with url: check_packing_list_item_path(item.packing_list, item), method: :patch do |f| %>
+    <%= button_tag type: "submit", class: "w-7 h-7 rounded border-2 flex items-center justify-center flex-shrink-0 #{item.checked ? 'bg-gold border-gold' : 'border-gold/50'}" do %>
+      <% if item.checked %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <span class="text-sm <%= item.checked ? 'line-through text-brown/40' : 'text-brown' %>">
+    <%= item.name %>
+  </span>
+
+</li>

--- a/app/views/items/check.turbo_stream.erb
+++ b/app/views/items/check.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@item) do %>
+  <%= render @item %>
+<% end %>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -18,11 +18,7 @@
     <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日</h2>
     <% if @morning_items.any? %>
       <ul class="space-y-2">
-        <% @morning_items.each do |item| %>
-          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
-            <span class="text-sm text-brown"><%= item.name %></span>
-          </li>
-        <% end %>
+        <%= render @morning_items %>
       </ul>
     <% else %>
       <p class="text-sm text-brown/40">アイテムはまだありません</p>
@@ -34,11 +30,7 @@
     <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">前日まで</h2>
     <% if @day_before_items.any? %>
       <ul class="space-y-2">
-        <% @day_before_items.each do |item| %>
-          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
-            <span class="text-sm text-brown"><%= item.name %></span>
-          </li>
-        <% end %>
+        <%= render @day_before_items %>
       </ul>
     <% else %>
       <p class="text-sm text-brown/40">アイテムはまだありません</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,11 @@ Rails.application.routes.draw do
   root "static_pages#top"
 
   resources :packing_lists, only: [:index, :new, :create, :show, :edit, :update] do
-    resources :items, only: [:index, :new, :create]
+    resources :items, only: [:index, :new, :create] do
+      member do
+        patch :check
+      end
+    end
   end
   # Defines the root path route ("/")
   # root "posts#index"


### PR DESCRIPTION
## 概要
リスト詳細画面で各持ち物のチェック状態を切り替え、DBに保存する機能を実装。
Turbo Streamを使用し、ページリロードなしでチェック状態が切り替わるUXを実現。

## 変更内容
- `items`にmemberルート`patch :check`を追加
- `ItemsController#check`アクションを追加（checkedをtoggle）
- `app/views/items/_item.html.erb`で切り出し
- `app/views/items/check.turbo_stream.erb`を追加（該当アイテムのみ差し替え）
- チェック済み・未チェックで見た目を切り替え（取り消し線・ボタン色）

## 動作確認
- [x] チェックボタンをタップするとページリロードなしで切り替わる
- [x] ページ再読み込み後もチェック状態が保持される
- [x] チェック済みと未チェックが視覚的に区別できる

close #19 