### PR TITLE
持ち物編集機能を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,6 +25,19 @@ class ItemsController < ApplicationController
     @item.update!(checked: !@item.checked)
   end
 
+  def edit
+    @item = @packing_list.items.find(params[:id])
+  end
+
+  def update
+    @item = @packing_list.items.find(params[:id])
+    if @item.update(item_params)
+      redirect_to packing_list_items_path(@packing_list), notice: "持ち物を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_packing_list

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,34 @@
+<div class="min-h-screen bg-cream py-10 px-4">
+  <div class="max-w-lg mx-auto">
+
+    <h1 class="text-2xl font-bold text-brown mb-6">持ち物を編集</h1>
+
+    <%= form_with model: [@packing_list, @item], data: { turbo: false } do |f| %>
+
+      <% if @item.errors.any? %>
+        <div class="mb-4 p-4 bg-red-50 border border-red-300 rounded-lg">
+          <ul class="list-disc list-inside text-red-600 text-sm">
+            <% @item.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="mb-4">
+        <%= f.label :name, "持ち物名", class: "block text-sm font-medium text-brown mb-1" %>
+        <%= f.text_field :name,
+            class: "w-full border border-brown/30 rounded-lg px-4 py-2 text-brown focus:outline-none focus:ring-2 focus:ring-gold" %>
+      </div>
+
+      <div class="flex gap-3">
+        <%= f.submit "保存する",
+            class: "bg-gold text-white font-semibold px-6 py-2 rounded-lg hover:opacity-80 cursor-pointer" %>
+        <%= link_to "キャンセル", packing_list_items_path(@packing_list),
+            class: "px-6 py-2 rounded-lg border border-brown/30 text-brown hover:bg-brown/5" %>
+      </div>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -14,8 +14,10 @@
     <% if @morning_items.any? %>
       <ul class="space-y-2 mb-3">
         <% @morning_items.each do |item| %>
-          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+          <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
             <span class="text-sm text-brown"><%= item.name %></span>
+            <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
+                class: "text-xs text-brown/40 hover:text-gold shrink-0" %>
           </li>
         <% end %>
       </ul>
@@ -31,8 +33,10 @@
     <% if @day_before_items.any? %>
       <ul class="space-y-2 mb-3">
         <% @day_before_items.each do |item| %>
-          <li class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+          <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
             <span class="text-sm text-brown"><%= item.name %></span>
+            <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
+                class: "text-xs text-brown/40 hover:text-gold shrink-0" %>
           </li>
         <% end %>
       </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   root "static_pages#top"
 
   resources :packing_lists, only: [:index, :new, :create, :show, :edit, :update] do
-    resources :items, only: [:index, :new, :create] do
+    resources :items, only: [:index, :new, :create, :edit, :update] do
       member do
         patch :check
       end


### PR DESCRIPTION
## 概要
登録済みの持ち物の名前を編集できる機能を実装した。

## 変更内容
- config/routes.rb：itemsに:edit, :updateを追加
- app/controllers/items_controller.rb：edit / updateアクションを追加
- app/views/items/index.html.erb：各アイテム行に編集リンクを追加
- app/views/items/edit.html.erb：編集フォーム画面を新規作成

## 動作確認
- 持ち物名を編集して保存できる
- バリデーションエラー時にエラーメッセージが表示される
- 他ユーザーの持ち物は編集できない 

## 備考
タイミングの編集は本リリースで実装予定。

close #13 