### PR TITLE
持ち物削除機能を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,6 +38,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @item = @packing_list.items.find(params[:id])
+    @item.destroy
+    redirect_to packing_list_items_path(@packing_list), notice: "持ち物を削除しました"
+  end
+
   private
 
   def set_packing_list

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -16,8 +16,15 @@
         <% @morning_items.each do |item| %>
           <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
             <span class="text-sm text-brown"><%= item.name %></span>
-            <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
-                class: "text-xs text-brown/40 hover:text-gold shrink-0" %>
+            <div class="flex items-center gap-3 shrink-0">
+              <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
+                  class: "text-xs text-brown/40 hover:text-gold" %>
+              <%= button_to "削除", packing_list_item_path(@packing_list, item),
+                  method: :delete,
+                  form: { data: { turbo_confirm: "「#{item.name}」を削除しますか？" } },
+                  form_class: "inline-flex items-center",
+                  class: "text-xs text-brown/40 hover:text-red-400" %>
+            </div>
           </li>
         <% end %>
       </ul>
@@ -35,8 +42,15 @@
         <% @day_before_items.each do |item| %>
           <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
             <span class="text-sm text-brown"><%= item.name %></span>
-            <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
-                class: "text-xs text-brown/40 hover:text-gold shrink-0" %>
+            <div class="flex items-center gap-3 shrink-0">
+              <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
+                  class: "text-xs text-brown/40 hover:text-gold" %>
+              <%= button_to "削除", packing_list_item_path(@packing_list, item),
+                  method: :delete,
+                  form: { data: { turbo_confirm: "「#{item.name}」を削除しますか？" } },
+                  form_class: "inline-flex items-center",
+                  class: "text-xs text-brown/40 hover:text-red-400" %>
+            </div>
           </li>
         <% end %>
       </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   root "static_pages#top"
 
   resources :packing_lists, only: [:index, :new, :create, :show, :edit, :update] do
-    resources :items, only: [:index, :new, :create, :edit, :update] do
+    resources :items, only: [:index, :new, :create, :edit, :update, :destroy] do
       member do
         patch :check
       end


### PR DESCRIPTION
## 概要
登録済みの持ち物を削除できる機能を実装した。

## 変更内容
- config/routes.rb：itemsに:destroyを追加
- app/controllers/items_controller.rb：destroyアクションを追加
- app/views/items/index.html.erb：各アイテム行に削除ボタンを追加

## 動作確認
- 持ち物を削除するとリスト詳細画面から消える
- 削除前に確認ダイアログが表示される
- 他ユーザーの持ち物は削除できない

close #14 