### PR TITLE
リスト一覧の︙メニューに編集・削除機能を追加

### DIFF
--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -1,5 +1,5 @@
 class PackingListsController < ApplicationController
-  before_action :set_packing_list, only: [:show, :edit, :update]
+  before_action :set_packing_list, only: [:show, :edit, :update, :destroy]
   
   def index
     @packing_lists = current_user.packing_lists.order(departure_date: :asc)
@@ -32,6 +32,11 @@ class PackingListsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @packing_list.destroy
+    redirect_to packing_lists_path, notice: "リストを削除しました"
   end
 
   private

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  toggle(event) {
+    event.stopPropagation()
+    const isHidden = this.menuTarget.classList.contains("hidden")
+    this.closeAll()
+    if (isHidden) {
+      this.menuTarget.classList.remove("hidden")
+    }
+  }
+
+  close() {
+    this.menuTarget.classList.add("hidden")
+  }
+
+  closeAll() {
+    document.querySelectorAll('[data-dropdown-target="menu"]').forEach(menu => {
+      menu.classList.add("hidden")
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import DropdownController from "./dropdown_controller"
+application.register("dropdown", DropdownController)

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -12,22 +12,37 @@
     <% else %>
       <div class="space-y-3">
         <% @packing_lists.each do |list| %>
-          <%= link_to packing_list_path(list), class: "block" do %>
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 relative">
+          <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 relative"
+               data-controller="dropdown"
+               data-action="click@window->dropdown#close">
 
-              <%# ︙ボタン %>
-              <button class="absolute top-3 right-3 text-gray-400 text-xl leading-none">⋮</button>
-
-              <h2 class="text-lg font-bold text-brown font-nunito pr-6"><%= list.name %></h2>
-
+            <%# カード本体（show画面へのリンク）%>
+            <%= link_to packing_list_path(list), class: "block pr-6" do %>
+              <h2 class="text-lg font-bold text-brown font-nunito"><%= list.name %></h2>
               <% if list.departure_date.present? %>
                 <p class="text-sm text-gray-500 mt-1">
                   出発日：<%= list.departure_date.strftime("%Y/%m/%d") %>
                 </p>
               <% end %>
+            <% end %>
 
+            <%# ︙ボタン %>
+            <button class="absolute top-3 right-3 text-gray-400 text-xl leading-none"
+                    data-action="click->dropdown#toggle">⋮</button>
+
+            <%# ドロップダウンメニュー %>
+            <div data-dropdown-target="menu"
+                 class="hidden absolute top-8 right-3 bg-white border border-gray-200 rounded-lg shadow-lg z-10 min-w-20">
+              <%= link_to "編集", edit_packing_list_path(list),
+                  class: "block px-4 py-2 text-sm text-brown hover:bg-cream rounded-t-lg text-center border-b border-gray-100" %>
+              <%= button_to "削除", packing_list_path(list),
+                  method: :delete,
+                  form: { data: { turbo_confirm: "「#{list.name}」を削除しますか？" } },
+                  class: "block w-full px-4 py-2 text-sm text-red-500 hover:bg-cream rounded-b-lg text-center",
+                  form_class: "w-full" %>
             </div>
-          <% end %>
+
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
   root "static_pages#top"
 
-  resources :packing_lists, only: [:index, :new, :create, :show, :edit, :update] do
+  resources :packing_lists, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
     resources :items, only: [:index, :new, :create, :edit, :update, :destroy] do
       member do
         patch :check


### PR DESCRIPTION
## 概要
リスト一覧画面の︙メニューにリスト編集・削除機能を追加した。

## 実装内容

### ︙メニュー
- Stimulusコントローラー（`dropdown_controller.js`）を新規作成
- ︙ボタンクリックで編集・削除メニューを表示
- メニュー外クリックで閉じる
- 複数リストがある場合、別のリストの︙を開くと前のメニューが自動で閉じる

### リスト削除
- `PackingListsController`に`destroy`アクションを追加
- 削除確認ダイアログを表示
- `dependent: :destroy`は実装済みのため、関連するitemsも合わせて削除される
- 他ユーザーのリストは削除不可

## 動作確認
- [x] ︙ボタンでメニューが開閉する
- [x] メニュー外クリックで閉じる
- [x] 別リストの︙を開くと前のメニューが閉じる
- [x] 編集リンクで編集画面に遷移する
- [x] 削除確認ダイアログが表示される
- [x] 削除するとリスト一覧から消える
- [x] 関連するitemsも合わせて削除される

closes #12 
closes #18 