### PR TITLE
モーダル開閉を実装

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("hello", HelloController)
 
 import DropdownController from "./dropdown_controller"
 application.register("dropdown", DropdownController)
+
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["overlay", "panel"]
+
+  open(event) {
+    const timing = event.currentTarget.dataset.timing
+    this.overlayTarget.dataset.timing = timing
+    this.overlayTarget.classList.remove("hidden")
+  }
+
+  close() {
+    this.overlayTarget.classList.add("hidden")
+  }
+
+  clickOutside(event) {
+    if (!this.panelTarget.contains(event.target)) {
+      this.close()
+    }
+  }
+}

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-lg mx-auto px-6 py-8">
+<div class="max-w-lg mx-auto px-6 py-8" data-controller="modal">
   <div class="relative flex items-center justify-center mb-6">
     <%= link_to "←", packing_list_path(@packing_list), class: "absolute left-0 text-brown text-xl" %>
     <h1 class="text-2xl font-bold text-brown">持ち物を編集</h1>
@@ -31,8 +31,12 @@
     <% else %>
       <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
     <% end %>
-    <%= link_to "+ 持ち物を追加", new_packing_list_item_path(@packing_list, timing: :morning),
-        class: "block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition" %>
+    <button
+      data-action="click->modal#open"
+      data-timing="morning"
+      class="block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition">
+      + 持ち物を追加
+    </button>
   </section>
 
   <section class="mb-8">
@@ -57,7 +61,29 @@
     <% else %>
       <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
     <% end %>
-    <%= link_to "+ 持ち物を追加", new_packing_list_item_path(@packing_list, timing: :day_before),
-        class: "block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition" %>
+    <button
+      data-action="click->modal#open"
+      data-timing="day_before"
+      class="block w-full border border-dashed border-brown/30 rounded-lg py-3 text-center text-sm text-brown/60 hover:border-gold hover:text-gold transition">
+      + 持ち物を追加
+    </button>
   </section>
+
+  <%# モーダル %>
+  <div
+    data-modal-target="overlay"
+    data-action="click->modal#clickOutside"
+    class="hidden fixed inset-0 bg-black/40 flex items-end justify-center z-50">
+    <div
+      data-modal-target="panel"
+      class="bg-cream w-full max-w-lg rounded-t-2xl p-6">
+      <h2 class="text-lg font-bold text-brown mb-4">持ち物を追加</h2>
+      <%# フォームは次ISSUEで実装 %>
+      <button
+        data-action="click->modal#close"
+        class="mt-4 w-full py-2 text-sm text-brown/60 hover:text-brown">
+        キャンセル
+      </button>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## 概要
Stimulusを使って持ち物追加モーダルの開閉を実装しました。

## 変更内容
- `modal_controller.js` を新規作成
- `index.js` にModalControllerを登録
- `items/index.html.erb` にモーダルHTMLを追加、追加ボタンをモーダル起動に変更

## 動作確認
- [x] 追加ボタンタップでモーダルが開く
- [x] モーダル外タップで閉じる
- [x] キャンセルボタンで閉じる

## 備考
- フォームの中身は別ISSUEで実装予定

Closes #20