### PR TITLE
持ち物追加モーダル内フォーム・Turbo連携

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,6 +4,7 @@ class ItemsController < ApplicationController
   def index
     @morning_items = @packing_list.items.where(timing: :morning)
     @day_before_items = @packing_list.items.where(timing: :day_before)
+    @item = @packing_list.items.build
   end
 
   def new
@@ -14,9 +15,17 @@ class ItemsController < ApplicationController
   def create
     @item = @packing_list.items.build(item_params)
     if @item.save
-      redirect_to packing_list_items_path(@packing_list), notice: "アイテムを追加しました"
+      @morning_items = @packing_list.items.where(timing: :morning)
+      @day_before_items = @packing_list.items.where(timing: :day_before)
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to packing_list_items_path(@packing_list) }
+      end
     else
-      render :new, status: :unprocessable_entity
+      respond_to do |format|
+        format.turbo_stream { render :error, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,11 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["overlay", "panel"]
+  static targets = ["overlay", "panel", "timing"]
 
   open(event) {
     const timing = event.currentTarget.dataset.timing
-    this.overlayTarget.dataset.timing = timing
+    this.timingTarget.value = timing
     this.overlayTarget.classList.remove("hidden")
   }
 
@@ -15,6 +15,12 @@ export default class extends Controller {
 
   clickOutside(event) {
     if (!this.panelTarget.contains(event.target)) {
+      this.close()
+    }
+  }
+
+  submitEnd(event) {
+    if (event.detail.success) {
       this.close()
     }
   }

--- a/app/views/items/_day_before_items.html.erb
+++ b/app/views/items/_day_before_items.html.erb
@@ -1,0 +1,16 @@
+<ul id="day-before-items" class="space-y-2 mb-3">
+  <% @day_before_items.each do |item| %>
+    <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+      <span class="text-sm text-brown"><%= item.name %></span>
+      <div class="flex items-center gap-3 shrink-0">
+        <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
+            class: "text-xs text-brown/40 hover:text-gold" %>
+        <%= button_to "削除", packing_list_item_path(@packing_list, item),
+            method: :delete,
+            form: { data: { turbo_confirm: "「#{item.name}」を削除しますか？" } },
+            form_class: "inline-flex items-center",
+            class: "text-xs text-brown/40 hover:text-red-400" %>
+      </div>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -1,0 +1,23 @@
+<div id="modal-form">
+  <%= form_with model: [@packing_list, @item],
+      data: { turbo: true, action: "turbo:submit-end->modal#submitEnd" } do |f| %>
+    <%= f.hidden_field :timing, value: "", data: { "modal-target": "timing" } %>
+
+    <% if @item.errors.any? %>
+      <div class="mb-3 text-sm text-red-500">
+        <% @item.errors.full_messages.each do |msg| %>
+          <p><%= msg %></p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="mb-4">
+      <%= f.text_field :name,
+          placeholder: "持ち物の名前",
+          class: "w-full border border-brown/30 rounded-lg px-3 py-2 text-sm text-brown focus:outline-none focus:border-gold" %>
+    </div>
+
+    <%= f.submit "追加する",
+        class: "w-full bg-gold text-white rounded-lg py-2 text-sm font-bold hover:opacity-90 transition" %>
+  <% end %>
+</div>

--- a/app/views/items/_morning_items.html.erb
+++ b/app/views/items/_morning_items.html.erb
@@ -1,0 +1,16 @@
+<ul id="morning-items" class="space-y-2 mb-3">
+  <% @morning_items.each do |item| %>
+    <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+      <span class="text-sm text-brown"><%= item.name %></span>
+      <div class="flex items-center gap-3 shrink-0">
+        <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
+            class: "text-xs text-brown/40 hover:text-gold" %>
+        <%= button_to "削除", packing_list_item_path(@packing_list, item),
+            method: :delete,
+            form: { data: { turbo_confirm: "「#{item.name}」を削除しますか？" } },
+            form_class: "inline-flex items-center",
+            class: "text-xs text-brown/40 hover:text-red-400" %>
+      </div>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/items/create.turbo_stream.erb
+++ b/app/views/items/create.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.replace "morning-items" do %>
+  <%= render "morning_items" %>
+<% end %>
+
+<%= turbo_stream.replace "day-before-items" do %>
+  <%= render "day_before_items" %>
+<% end %>
+
+<%= turbo_stream.replace "modal-form" do %>
+  <%= render "form" %>
+<% end %>

--- a/app/views/items/error.turbo_stream.erb
+++ b/app/views/items/error.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "modal-form" do %>
+  <%= render "form" %>
+<% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -12,22 +12,7 @@
   <section class="mb-8">
     <h2 class="text-base font-bold text-gold border-b border-brown/30 pb-1 mb-4">当日</h2>
     <% if @morning_items.any? %>
-      <ul class="space-y-2 mb-3">
-        <% @morning_items.each do |item| %>
-          <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
-            <span class="text-sm text-brown"><%= item.name %></span>
-            <div class="flex items-center gap-3 shrink-0">
-              <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
-                  class: "text-xs text-brown/40 hover:text-gold" %>
-              <%= button_to "削除", packing_list_item_path(@packing_list, item),
-                  method: :delete,
-                  form: { data: { turbo_confirm: "「#{item.name}」を削除しますか？" } },
-                  form_class: "inline-flex items-center",
-                  class: "text-xs text-brown/40 hover:text-red-400" %>
-            </div>
-          </li>
-        <% end %>
-      </ul>
+      <%= render "morning_items" %>
     <% else %>
       <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
     <% end %>
@@ -42,22 +27,7 @@
   <section class="mb-8">
     <h2 class="text-base font-bold text-gold border-b border-brown/30 pb-1 mb-4">前日</h2>
     <% if @day_before_items.any? %>
-      <ul class="space-y-2 mb-3">
-        <% @day_before_items.each do |item| %>
-          <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
-            <span class="text-sm text-brown"><%= item.name %></span>
-            <div class="flex items-center gap-3 shrink-0">
-              <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
-                  class: "text-xs text-brown/40 hover:text-gold" %>
-              <%= button_to "削除", packing_list_item_path(@packing_list, item),
-                  method: :delete,
-                  form: { data: { turbo_confirm: "「#{item.name}」を削除しますか？" } },
-                  form_class: "inline-flex items-center",
-                  class: "text-xs text-brown/40 hover:text-red-400" %>
-            </div>
-          </li>
-        <% end %>
-      </ul>
+      <%= render "day_before_items" %>
     <% else %>
       <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
     <% end %>
@@ -71,6 +41,7 @@
 
   <%# モーダル %>
   <div
+    id="modal-overlay"
     data-modal-target="overlay"
     data-action="click->modal#clickOutside"
     class="hidden fixed inset-0 bg-black/40 flex items-end justify-center z-50">
@@ -78,7 +49,7 @@
       data-modal-target="panel"
       class="bg-cream w-full max-w-lg rounded-t-2xl p-6">
       <h2 class="text-lg font-bold text-brown mb-4">持ち物を追加</h2>
-      <%# フォームは次ISSUEで実装 %>
+      <%= render "form" %>
       <button
         data-action="click->modal#close"
         class="mt-4 w-full py-2 text-sm text-brown/60 hover:text-brown">


### PR DESCRIPTION
## 概要
モーダル内に持ち物追加フォームを実装し、Turbo Streamを使って送信後にページ遷移なくリストを更新する機能を実装した。

## 変更内容

### コントローラー
- `ItemsController#index` に `@item` を追加
- `ItemsController#create` を `respond_to` でTurbo Stream対応に変更

### ビュー
- `_form.html.erb` を新規作成（hiddenフィールドでtimingを保持）
- `_morning_items.html.erb` を新規作成
- `_day_before_items.html.erb` を新規作成
- `create.turbo_stream.erb` を新規作成（リスト更新 + フォームリセット）
- `error.turbo_stream.erb` を新規作成（エラー表示）
- `items/index.html.erb` をパーシャル利用に更新、モーダル内にフォームを組み込み

### Stimulus
- `modal_controller.js` に `submitEnd()` を追加（送信成功時にモーダルを閉じる）
- `timing` を `static targets` に追加し、`open()` 時にhiddenフィールドに値を注入

## 動作確認
- モーダル内から持ち物を追加できる
- 追加後にページ遷移なくリストが更新される
- バリデーションエラーがモーダル内に表示される

Closes #27