### PR TITLE
修正：持ち物追加後のモーダルの入力欄を空にする

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,7 @@ class ItemsController < ApplicationController
     if @item.save
       @morning_items = @packing_list.items.where(timing: :morning)
       @day_before_items = @packing_list.items.where(timing: :day_before)
+      @item = @packing_list.items.build
       respond_to do |format|
         format.turbo_stream
         format.html { redirect_to packing_list_items_path(@packing_list) }


### PR DESCRIPTION
## 概要
持ち物追加後に再度モーダルを開いたとき、前回入力した持ち物名が残っているバグを修正した。

## 原因
`create` アクションの成功時に `@item` を上書きしていなかったため、Turbo Streamで `_form.html.erb` を再レンダリングする際に直前に保存されたアイテムの値が残っていた。

## 修正内容
- `ItemsController#create` の成功時に `@item = @packing_list.items.build` を追加し、空のインスタンスで上書きするように修正

## 動作確認
- 持ち物追加後、再度モーダルを開いたとき入力欄が空になっている
