### PR TITLE
持ち物編集モーダルを実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,9 +42,15 @@ class ItemsController < ApplicationController
   def update
     @item = @packing_list.items.find(params[:id])
     if @item.update(item_params)
-      redirect_to packing_list_items_path(@packing_list), notice: "持ち物を更新しました"
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to packing_list_items_path(@packing_list) }
+      end
     else
-      render :edit, status: :unprocessable_entity
+      respond_to do |format|
+        format.turbo_stream { render :error_update, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/javascript/controllers/edit_modal_controller.js
+++ b/app/javascript/controllers/edit_modal_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["overlay", "panel"]
+
+  open() {
+    this.overlayTarget.classList.remove("hidden")
+  }
+
+  close() {
+    this.overlayTarget.classList.add("hidden")
+  }
+
+  clickOutside(event) {
+    if (!this.panelTarget.contains(event.target)) {
+      this.close()
+    }
+  }
+
+  submitEnd(event) {
+    if (event.detail.success) {
+      this.close()
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("dropdown", DropdownController)
 
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
+
+import EditModalController from "./edit_modal_controller"
+application.register("edit-modal", EditModalController)

--- a/app/views/items/_day_before_items.html.erb
+++ b/app/views/items/_day_before_items.html.erb
@@ -1,16 +1,5 @@
 <ul id="day-before-items" class="space-y-2 mb-3">
   <% @day_before_items.each do |item| %>
-    <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
-      <span class="text-sm text-brown"><%= item.name %></span>
-      <div class="flex items-center gap-3 shrink-0">
-        <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
-            class: "text-xs text-brown/40 hover:text-gold" %>
-        <%= button_to "削除", packing_list_item_path(@packing_list, item),
-            method: :delete,
-            form: { data: { turbo_confirm: "「#{item.name}」を削除しますか？" } },
-            form_class: "inline-flex items-center",
-            class: "text-xs text-brown/40 hover:text-red-400" %>
-      </div>
-    </li>
+    <%= render "items/item", item: item %>
   <% end %>
 </ul>

--- a/app/views/items/_edit_form.html.erb
+++ b/app/views/items/_edit_form.html.erb
@@ -1,0 +1,24 @@
+<div id="edit-modal-<%= item.id %>">
+  <%= form_with model: [@packing_list, item],
+      data: { action: "turbo:submit-end->edit-modal#submitEnd" } do |f| %>
+
+    <% if item.errors.any? %>
+      <ul class="mb-3 text-sm text-red-500 space-y-1">
+        <% item.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <%= f.hidden_field :timing %>
+
+    <div class="mb-4">
+      <%= f.text_field :name,
+          class: "w-full border border-brown/30 rounded-lg px-3 py-2 text-sm text-brown focus:outline-none  focus:border-gold",
+          placeholder: "持ち物の名前" %>
+    </div>
+
+    <%= f.submit "保存する",
+        class: "w-full py-2 text-sm bg-gold text-white rounded-lg hover:opacity-90" %>
+    <% end %>
+</div>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,4 +1,8 @@
-<li id="<%= dom_id(item) %>" class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+<li id="<%= dom_id(item) %>"
+    class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm"
+    data-controller="edit-modal">
+
+  <%# チェックボックス %>
   <%= form_with url: check_packing_list_item_path(item.packing_list, item), method: :patch do |f| %>
     <%= button_tag type: "submit", class: "w-7 h-7 rounded border-2 flex items-center justify-center flex-shrink-0 #{item.checked ? 'bg-gold border-gold' : 'border-gold/50'}" do %>
       <% if item.checked %>
@@ -9,8 +13,39 @@
     <% end %>
   <% end %>
 
-  <span class="text-sm <%= item.checked ? 'line-through text-brown/40' : 'text-brown' %>">
+  <%# アイテム名 %>
+  <span class="flex-1 text-sm <%= item.checked ? 'line-through text-brown/40' : 'text-brown' %>">
     <%= item.name %>
   </span>
+
+  <%# 編集・削除ボタン %>
+  <div class="flex items-center gap-3 shrink-0">
+    <button type="button"
+            data-action="edit-modal#open"
+            class="text-xs text-brown/40 hover:text-gold">
+      編集
+    </button>
+    <%= button_to "削除", packing_list_item_path(item.packing_list, item),
+        method: :delete,
+        form: { data: { turbo_confirm: "「#{item.name}」を削除しますか？" } },
+        form_class: "inline-flex items-center",
+        class: "text-xs text-brown/40 hover:text-red-400" %>
+  </div>
+
+  <%# 編集モーダル %>
+  <div data-edit-modal-target="overlay"
+       class="hidden fixed inset-0 z-50 flex items-end justify-center bg-black/40"
+       data-action="click->edit-modal#clickOutside">
+    <div data-edit-modal-target="panel"
+         class="bg-cream rounded-t-2xl shadow-xl w-full max-w-lg p-6">
+      <h2 class="text-lg font-semibold text-brown mb-4">持ち物を編集</h2>
+      <%= render "items/edit_form", item: item, packing_list: @packing_list %>
+      <button type="button"
+          data-action="edit-modal#close"
+          class="mt-4 w-full py-2 text-sm text-brown/60 hover:text-brown">
+        キャンセル
+      </button>
+    </div>
+  </div>
 
 </li>

--- a/app/views/items/_morning_items.html.erb
+++ b/app/views/items/_morning_items.html.erb
@@ -1,16 +1,5 @@
 <ul id="morning-items" class="space-y-2 mb-3">
   <% @morning_items.each do |item| %>
-    <li class="flex items-center justify-between gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
-      <span class="text-sm text-brown"><%= item.name %></span>
-      <div class="flex items-center gap-3 shrink-0">
-        <%= link_to "編集", edit_packing_list_item_path(@packing_list, item),
-            class: "text-xs text-brown/40 hover:text-gold" %>
-        <%= button_to "削除", packing_list_item_path(@packing_list, item),
-            method: :delete,
-            form: { data: { turbo_confirm: "「#{item.name}」を削除しますか？" } },
-            form_class: "inline-flex items-center",
-            class: "text-xs text-brown/40 hover:text-red-400" %>
-      </div>
-    </li>
+    <%= render "items/item", item: item %>
   <% end %>
 </ul>

--- a/app/views/items/error_update.turbo_stream.erb
+++ b/app/views/items/error_update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "edit-modal-#{@item.id}" do %>
+  <%= render "items/edit_form", item: @item, packing_list: @packing_list %>
+<% end %>

--- a/app/views/items/update.turbo_stream.erb
+++ b/app/views/items/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@item) do %>
+  <%= render "items/item", item: @item %>
+<% end %>


### PR DESCRIPTION
## 概要
持ち物編集をページ遷移からモーダル表示に切り替えた。

## 実装内容

### Stimulusコントローラー
- `edit_modal_controller.js`を新規作成
- `open()` / `close()` / `clickOutside()` / `submitEnd()`を実装
- `index.js`に登録

### ビュー
- `_edit_form.html.erb`を新規作成（編集フォーム）
- `_item.html.erb`にモーダルを組み込み
- `_morning_items.html.erb` / `_day_before_items.html.erb`を`render "items/item"`に変更
- 追加モーダルと構造・スタイルを統一

### コントローラー
- `ItemsController#update`をTurbo Stream対応に変更

### Turbo Streamテンプレート
- `update.turbo_stream.erb`：編集成功時に該当アイテムの`<li>`要素を更新
- `error_update.turbo_stream.erb`：バリデーションエラー時にフォームをエラーメッセージ付きで再表示

## 完了条件の確認
- [x] モーダルが開閉できる
- [x] モーダル内から持ち物を編集できる
- [x] 編集後にページ遷移なくリストが更新される
- [x] バリデーションエラーがモーダル内に表示される

## 関連ISSUE
closes #21