### PR TITLE
修正：リスト詳細画面の編集・削除ボタンを表示しない

### DIFF
--- a/app/views/items/_check_item.html.erb
+++ b/app/views/items/_check_item.html.erb
@@ -1,0 +1,15 @@
+<li id="<%= dom_id(item) %>" class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
+  <%= form_with url: check_packing_list_item_path(item.packing_list, item), method: :patch do |f| %>
+    <%= button_tag type: "submit", class: "w-7 h-7 rounded border-2 flex items-center justify-center flex-shrink-0 #{item.checked ? 'bg-gold border-gold' : 'border-gold/50'}" do %>
+      <% if item.checked %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <span class="flex-1 text-sm <%= item.checked ? 'line-through text-brown/40' : 'text-brown' %>">
+    <%= item.name %>
+  </span>
+</li>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -18,7 +18,7 @@
     <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日</h2>
     <% if @morning_items.any? %>
       <ul class="space-y-2">
-        <%= render @morning_items %>
+        <%= render partial: "items/check_item", collection: @morning_items, as: :item %>
       </ul>
     <% else %>
       <p class="text-sm text-brown/40">アイテムはまだありません</p>
@@ -30,7 +30,7 @@
     <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">前日まで</h2>
     <% if @day_before_items.any? %>
       <ul class="space-y-2">
-        <%= render @day_before_items %>
+        <%= render partial: "items/check_item", collection: @day_before_items, as: :item %>
       </ul>
     <% else %>
       <p class="text-sm text-brown/40">アイテムはまだありません</p>


### PR DESCRIPTION
## 概要
リスト詳細画面に編集・削除ボタンが表示されていたため、表示しないように修正した。

## 原因
ISSUE #21で`_item.html.erb`に編集・削除ボタンとモーダルを追加した際、
詳細画面でも同じパーシャルを使用していたため意図しない表示が発生していた。

## 対応
- `_check_item.html.erb`を新規作成（チェックボックスとアイテム名のみ）
- `show.html.erb`で`_check_item.html.erb`を使用するよう変更

## 確認項目
- [x] リスト詳細画面で編集・削除ボタンが表示されない
- [x] リスト詳細画面でチェックボックスが正常に動作する
- [x] 編集画面で編集・削除ボタンが正常に表示される