### PR TITLE
fix:アイテムチェックについて2点修正

### DIFF
--- a/app/views/items/_check_item.html.erb
+++ b/app/views/items/_check_item.html.erb
@@ -1,5 +1,5 @@
 <li id="<%= dom_id(item) %>" class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm">
-  <%= form_with url: check_packing_list_item_path(item.packing_list, item), method: :patch do |f| %>
+  <%= form_with url: check_packing_list_item_path(item.packing_list, item, source: "show"), method: :patch do |f| %>
     <%= button_tag type: "submit", class: "w-7 h-7 rounded border-2 flex items-center justify-center flex-shrink-0 #{item.checked ? 'bg-gold border-gold' : 'border-gold/50'}" do %>
       <% if item.checked %>
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -2,19 +2,8 @@
     class="flex items-center gap-3 py-2 px-3 bg-white rounded-lg shadow-sm"
     data-controller="edit-modal">
 
-  <%# チェックボックス %>
-  <%= form_with url: check_packing_list_item_path(item.packing_list, item), method: :patch do |f| %>
-    <%= button_tag type: "submit", class: "w-7 h-7 rounded border-2 flex items-center justify-center flex-shrink-0 #{item.checked ? 'bg-gold border-gold' : 'border-gold/50'}" do %>
-      <% if item.checked %>
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-        </svg>
-      <% end %>
-    <% end %>
-  <% end %>
-
   <%# アイテム名 %>
-  <span class="flex-1 text-sm <%= item.checked ? 'line-through text-brown/40' : 'text-brown' %>">
+  <span class="flex-1 text-sm text-brown">
     <%= item.name %>
   </span>
 

--- a/app/views/items/check.turbo_stream.erb
+++ b/app/views/items/check.turbo_stream.erb
@@ -1,3 +1,7 @@
 <%= turbo_stream.replace dom_id(@item) do %>
-  <%= render @item %>
+  <% if params[:source] == "show" %>
+    <%= render "items/check_item", item: @item %>
+  <% else %>
+    <%= render "items/item", item: @item %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
## 概要
2点修正した。

##  修正1：詳細画面でチェック時に編集・削除ボタンが表示される
### 原因
`check.turbo_stream.erb`で`render @item`を使っていたため、
チェック後のDOM更新で`_item.html.erb`（編集・削除ボタンを含む）が使われていた。

### 対応
- `_check_item.html.erb`のフォームに`source: "show"`パラメーターを追加
- `check.turbo_stream.erb`で`params[:source]`を判定し、使用するファイルを切り替え

## 修正2：アイテム編集画面にチェックボックスが表示されていた
### 原因
編集画面用の`_item.html.erb`にチェックボックスが含まれていた。
編集画面はチェック機能を持たない設計のため不要な表示だった。

### 対応
- `_item.html.erb`からチェックボックスを削除
- あわせてチェック状態による打ち消し線（line-through）も削除

## 確認項目
- [x] 詳細画面でチェックしても編集・削除ボタンが表示されない
- [x] 詳細画面のチェック機能が正常に動作する
- [x] 編集画面にチェックボックスが表示されない
- [x] 編集画面の編集・削除ボタンが正常に動作する
- [x] 編集モーダルが正常に動作する