### PR TITLE
タイミング別セクションのUI調整

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 
   <section class="mb-8">
-    <h2 class="text-base font-bold text-gold border-b border-brown/30 pb-1 mb-4">当日</h2>
+    <h2 class="text-xl font-bold text-gold border-b border-brown/30 pb-1 mb-4">当日</h2>
     <% if @morning_items.any? %>
       <%= render "morning_items" %>
     <% else %>
@@ -25,11 +25,11 @@
   </section>
 
   <section class="mb-8">
-    <h2 class="text-base font-bold text-gold border-b border-brown/30 pb-1 mb-4">前日</h2>
+    <h2 class="text-xl font-bold text-gold border-b border-brown/30 pb-1 mb-4">前日まで</h2>
     <% if @day_before_items.any? %>
       <%= render "day_before_items" %>
     <% else %>
-      <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+      <p class="text-sm text-brown/400 mb-3">アイテムはまだありません</p>
     <% end %>
     <button
       data-action="click->modal#open"

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -8,7 +8,7 @@
 
     <%# リスト一覧 %>
     <% if @packing_lists.empty? %>
-      <p class="text-center text-gray-400 mt-20">リストがありません</p>
+      <p class="text-center text-brown/60 mt-20">リストがありません</p>
     <% else %>
       <div class="space-y-3">
         <% @packing_lists.each do |list| %>
@@ -20,14 +20,14 @@
             <%= link_to packing_list_path(list), class: "block pr-6" do %>
               <h2 class="text-lg font-bold text-brown font-nunito"><%= list.name %></h2>
               <% if list.departure_date.present? %>
-                <p class="text-sm text-gray-500 mt-1">
+                <p class="text-sm text-brown/60 mt-1">
                   出発日：<%= list.departure_date.strftime("%Y/%m/%d") %>
                 </p>
               <% end %>
             <% end %>
 
             <%# ︙ボタン %>
-            <button class="absolute top-3 right-3 text-gray-400 text-xl leading-none"
+            <button class="absolute top-3 right-3 text-brown/60 text-xl leading-none"
                     data-action="click->dropdown#toggle">⋮</button>
 
             <%# ドロップダウンメニュー %>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -5,7 +5,7 @@
     <%= link_to "編集", packing_list_items_path(@packing_list), class: "absolute right-0 text-sm text-gold font-semibold" %>
   </div>
 
-  <div class="text-center text-sm text-brown/60 mb-8">
+  <div class="text-sm text-brown/60 mb-8">
     <% if @packing_list.departure_date %>
       出発日：<%= @packing_list.departure_date.strftime("%Y年%m月%d日") %>
     <% else %>
@@ -14,26 +14,26 @@
   </div>
 
   <%# 当日朝セクション（上に配置） %>
-  <section class="mb-8">
-    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日</h2>
+  <section class="mb-6 border border-gold/20 rounded-xl p-4 bg-gold/5">
+    <h2 class="text-xl font-bold text-gold border-b border-gold/30 pb-1 mb-4">当日</h2>
     <% if @morning_items.any? %>
       <ul class="space-y-2">
         <%= render partial: "items/check_item", collection: @morning_items, as: :item %>
       </ul>
     <% else %>
-      <p class="text-sm text-brown/40">アイテムはまだありません</p>
+      <p class="text-sm text-brown/60">アイテムはまだありません</p>
     <% end %>
   </section>
 
   <%# 前日セクション（下に配置） %>
-  <section class="mb-8">
-    <h2 class="text-base font-bold text-gold border-b border-gold/30 pb-1 mb-4">前日まで</h2>
+  <section class="mb-6 border border-gold/20 rounded-xl p-4 bg-gold/5">
+    <h2 class="text-xl font-bold text-gold border-b border-gold/30 pb-1 mb-4">前日まで</h2>
     <% if @day_before_items.any? %>
       <ul class="space-y-2">
         <%= render partial: "items/check_item", collection: @day_before_items, as: :item %>
       </ul>
     <% else %>
-      <p class="text-sm text-brown/40">アイテムはまだありません</p>
+      <p class="text-sm text-brown/60">アイテムはまだありません</p>
     <% end %>
   </section>
 </div>


### PR DESCRIPTION
## 概要
タイミング別セクションの見た目を整えた。セクションヘッダーのデザイン調整、アイテムカードとの視覚的な区別、スマートフォンでの表示確認を実施。

## 変更内容
- 詳細画面の当日・前日セクションに枠線と背景色を追加し、カード状に区切って視覚的に区別しやすくした
- 出発日表示を中央寄せから左寄せに変更
- リストなし・アイテムなし時のテキストカラーを統一

## 動作確認
- [x] 当日・前日のセクションが視覚的に区別できる
- [x] スマートフォンサイズで崩れず表示される

closes #16