### PR TITLE
リスト一覧・詳細画面で進捗表示

### DIFF
--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -2,7 +2,7 @@ class PackingListsController < ApplicationController
   before_action :set_packing_list, only: [:show, :edit, :update, :destroy]
   
   def index
-    @packing_lists = current_user.packing_lists.order(departure_date: :asc)
+    @packing_lists = current_user.packing_lists.includes(:items).order(departure_date: :asc)
   end
 
   def new
@@ -42,7 +42,7 @@ class PackingListsController < ApplicationController
   private
 
   def set_packing_list
-    @packing_list = current_user.packing_lists.find(params[:id])
+    @packing_list = current_user.packing_lists.includes(:items).find(params[:id])
   rescue ActiveRecord::RecordNotFound
     render file: "#{Rails.root}/public/404.html", status: :not_found, layout: false
   end

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -3,4 +3,14 @@ class PackingList < ApplicationRecord
   
   belongs_to :user
   has_many :items, dependent: :destroy
+
+  def morning_progress
+    morning_items = items.where(timing: :morning)
+    { checked: morning_items.where(checked: true).count, total: morning_items.count }
+  end
+
+  def day_before_progress
+    day_before_items = items.where(timing: :day_before)
+    { checked: day_before_items.where(checked: true).count, total: day_before_items.count }
+  end
 end

--- a/app/views/items/check.turbo_stream.erb
+++ b/app/views/items/check.turbo_stream.erb
@@ -5,3 +5,7 @@
     <%= render "items/item", item: @item %>
   <% end %>
 <% end %>
+
+<%= turbo_stream.replace dom_id(@item.packing_list, :progress) do %>
+  <%= render "packing_lists/progress", packing_list: @item.packing_list %>
+<% end %>

--- a/app/views/packing_lists/_progress.html.erb
+++ b/app/views/packing_lists/_progress.html.erb
@@ -1,0 +1,4 @@
+<div id="<%= dom_id(packing_list, :progress) %>" class="flex gap-4 text-sm text-brown/60">
+  <span>当日：<%= packing_list.morning_progress[:checked] %>/<%= packing_list.morning_progress[:total] %></span>
+  <span>前日：<%= packing_list.day_before_progress[:checked] %>/<%= packing_list.day_before_progress[:total] %></span>
+</div>

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -24,6 +24,7 @@
                   出発日：<%= list.departure_date.strftime("%Y/%m/%d") %>
                 </p>
               <% end %>
+              <%= render "progress", packing_list: list %>
             <% end %>
 
             <%# ︙ボタン %>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -11,6 +11,7 @@
     <% else %>
       出発日未設定
     <% end %>
+    <%= render "progress", packing_list: @packing_list %>
   </div>
 
   <%# 当日朝セクション（上に配置） %>


### PR DESCRIPTION
## 概要
リスト一覧画面とリスト詳細画面に、タイミング別（当日・前日）のチェック進捗を表示する。
チェック切替時はTurbo Streamでリアルタイムに更新される。

## 変更内容
- PackingListモデルにmorning_progress / day_before_progressメソッドを追加
- _progress.html.erbを新規作成
- 一覧画面・詳細画面に進捗表示を追加
- check.turbo_stream.erbに進捗のTurbo Stream updateを追加
- N+1対策としてincludes(:items)をindexとset_packing_listに追加

## 動作確認
- [x] 一覧画面の各カードに「当日：X/Y　前日：X/Y」が表示される
- [x] 詳細画面にも同様の進捗が表示される
- [x] チェック切替時にページリロードなしで進捗がリアルタイム更新される
- [x] 数字が正しい

closes #57 