### PR TITLE
fix:リスト一覧と持ち物編集画面に出発日未定を表示

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -7,6 +7,8 @@
   <p class="text-sm text-brown/60 mb-1">旅行名：<%= @packing_list.name %></p>
   <% if @packing_list.departure_date %>
     <p class="text-sm text-brown/60 mb-6">出発日：<%= @packing_list.departure_date.strftime("%Y年%m月%d日") %></p>
+  <% else %>
+    <p class="text-sm text-brown/60 mb-6">出発日未定</p>
   <% end %>
 
   <section class="mb-8">
@@ -14,7 +16,7 @@
     <% if @morning_items.any? %>
       <%= render "morning_items" %>
     <% else %>
-      <p class="text-sm text-brown/40 mb-3">アイテムはまだありません</p>
+      <p class="text-sm text-brown/60 mb-3">アイテムはまだありません</p>
     <% end %>
     <button
       data-action="click->modal#open"
@@ -29,7 +31,7 @@
     <% if @day_before_items.any? %>
       <%= render "day_before_items" %>
     <% else %>
-      <p class="text-sm text-brown/400 mb-3">アイテムはまだありません</p>
+      <p class="text-sm text-brown/60 mb-3">アイテムはまだありません</p>
     <% end %>
     <button
       data-action="click->modal#open"

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -23,6 +23,8 @@
                 <p class="text-sm text-brown/60 mt-1">
                   出発日：<%= list.departure_date.strftime("%Y/%m/%d") %>
                 </p>
+              <% else %>
+                <p class="text-sm text-brown/60 mt-1">出発日未定</p>
               <% end %>
               <%= render "progress", packing_list: list %>
             <% end %>


### PR DESCRIPTION
## 概要
出発日が未設定のリストに対して「出発日未定」と表示されるよう修正。
これまでは出発日がない場合に何も表示されていなかった。

## 変更内容
- 一覧画面（packing_lists/index.html.erb）：出発日未設定時に「出発日未定」を表示
- 持ち物編集画面（items/index.html.erb）：出発日未設定時に「出発日未定」を表示

## 動作確認
- [x] 一覧画面で出発日未設定のリストに「出発日未定」が表示される
- [x] 持ち物編集画面で出発日未設定のリストに「出発日未定」が表示される
- [x] 出発日が設定済みのリストは従来通り日付が表示される