### PR TITLE
動作確認を実施・不具合を修正

### DIFF
--- a/app/javascript/controllers/edit_modal_controller.js
+++ b/app/javascript/controllers/edit_modal_controller.js
@@ -9,6 +9,11 @@ export default class extends Controller {
 
   close() {
     this.overlayTarget.classList.add("hidden")
+    const errorList = this.element.querySelector(".text-red-500")
+    if (errorList) errorList.remove()
+    const nameInput = this.element.querySelector("input[name='item[name]']")
+    const originalName = this.element.querySelector("[data-item-name]").dataset.itemName
+    if (nameInput) nameInput.value = originalName
   }
 
   clickOutside(event) {

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -11,6 +11,8 @@ export default class extends Controller {
 
   close() {
     this.overlayTarget.classList.add("hidden")
+    const errorDiv = document.getElementById("modal-form-errors")
+    if (errorDiv) errorDiv.remove()
   }
 
   clickOutside(event) {

--- a/app/views/items/_day_before_items.html.erb
+++ b/app/views/items/_day_before_items.html.erb
@@ -1,5 +1,9 @@
 <ul id="day-before-items" class="space-y-2 mb-3">
-  <% @day_before_items.each do |item| %>
-    <%= render "items/item", item: item %>
+  <% if @day_before_items.any? %>
+    <% @day_before_items.each do |item| %>
+      <%= render "items/item", item: item %>
+    <% end %>
+  <% else %>
+    <p class="text-sm text-brown/60">アイテムはまだありません</p>
   <% end %>
 </ul>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -1,10 +1,10 @@
 <div id="modal-form">
   <%= form_with model: [@packing_list, @item],
       data: { turbo: true, action: "turbo:submit-end->modal#submitEnd" } do |f| %>
-    <%= f.hidden_field :timing, value: "", data: { "modal-target": "timing" } %>
+    <%= f.hidden_field :timing, data: { "modal-target": "timing" } %>
 
     <% if @item.errors.any? %>
-      <div class="mb-3 text-sm text-red-500">
+      <div id="modal-form-errors" class="mb-3 text-sm text-red-500">
         <% @item.errors.full_messages.each do |msg| %>
           <p><%= msg %></p>
         <% end %>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -3,7 +3,7 @@
     data-controller="edit-modal">
 
   <%# アイテム名 %>
-  <span class="flex-1 text-sm text-brown">
+  <span class="flex-1 text-sm text-brown" data-item-name="<%= item.name %>">
     <%= item.name %>
   </span>
 

--- a/app/views/items/_morning_items.html.erb
+++ b/app/views/items/_morning_items.html.erb
@@ -1,5 +1,9 @@
 <ul id="morning-items" class="space-y-2 mb-3">
-  <% @morning_items.each do |item| %>
-    <%= render "items/item", item: item %>
+  <% if @morning_items.any? %>
+    <% @morning_items.each do |item| %>
+      <%= render "items/item", item: item %>
+    <% end %>
+  <% else %>
+    <p class="text-sm text-brown/60">アイテムはまだありません</p>
   <% end %>
 </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -13,11 +13,7 @@
 
   <section class="mb-8">
     <h2 class="text-xl font-bold text-gold border-b border-brown/30 pb-1 mb-4">当日</h2>
-    <% if @morning_items.any? %>
       <%= render "morning_items" %>
-    <% else %>
-      <p class="text-sm text-brown/60 mb-3">アイテムはまだありません</p>
-    <% end %>
     <button
       data-action="click->modal#open"
       data-timing="morning"
@@ -28,11 +24,7 @@
 
   <section class="mb-8">
     <h2 class="text-xl font-bold text-gold border-b border-brown/30 pb-1 mb-4">前日まで</h2>
-    <% if @day_before_items.any? %>
       <%= render "day_before_items" %>
-    <% else %>
-      <p class="text-sm text-brown/60 mb-3">アイテムはまだありません</p>
-    <% end %>
     <button
       data-action="click->modal#open"
       data-timing="day_before"

--- a/app/views/packing_lists/create.html.erb
+++ b/app/views/packing_lists/create.html.erb
@@ -1,2 +1,0 @@
-<h1>PackingLists#create</h1>
-<p>Find me in app/views/packing_lists/create.html.erb</p>

--- a/app/views/packing_lists/new.html.erb
+++ b/app/views/packing_lists/new.html.erb
@@ -3,7 +3,7 @@
 
   <%# ヘッダー %>
     <div class="relative flex items-center justify-center mb-4 w-full">
-    <%= link_to root_path, class: "absolute left-0 text-brown text-xl font-bold" do %>
+    <%= link_to packing_lists_path, class: "absolute left-0 text-brown text-xl font-bold" do %>
         ←
     <% end %>
     <h1 class="text-4xl font-bold text-brown tracking-wide">リスト作成</h1>
@@ -29,7 +29,7 @@
     <div>
       <%= f.label :name, "リスト名", class: "block text-sm font-semibold text-brown mb-2" %>
       <%= f.text_field :name,
-          placeholder: "大阪旅行",
+          placeholder: "旅行",
           class: "w-full px-4 py-3 border border-brown-mid rounded-xl bg-white text-text-main placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-gold" %>
     </div>
 


### PR DESCRIPTION
## 概要
MVPの動作確認を実施し、発見した不具合を修正した。

## 動作確認項目
- 新規登録 → ログイン → リスト作成 → 持ち物追加 → チェックの一連の流れ
- 編集・削除の正常動作
- 他ユーザーのデータへの不正アクセス不可

## 発見・修正した不具合

### 1. 戻るボタンがトップ画面に遷移する
- **原因**: 戻り先が一時的にトップ画面に指定していたままになっていた
- **修正**: `packing_lists_path` に指定

### 2. 不要ファイルの削除
- **原因**: 自動生成した不要ファイル
- **修正**: `packing_lists/create.html.erb` を削除

### 3. 初回持ち物追加が即時表示されない
- **原因**: アイテム0件のとき `if @morning_items.any?` の分岐により `<ul id="morning-items">` がDOMに存在せず、Turbo Streamのreplaceターゲットが見つからなかった
- **修正**: ファイル内に `<ul>` を常に描画し、空状態の表示も管理

### 4. 追加モーダル：エラー後にtimingが消えて保存不能になる
- **原因**: `hidden_field` に `value: ""` を固定していたため、エラー後のフォームreplace時にtimingが空になった
- **修正**: `value: ""` を削除し、`@item.timing` の値を自動で使用

### 5. 追加モーダル：閉じてもエラーメッセージが残る
- **原因**: モーダルを閉じてもDOMがreplaceされたままだった
- **修正**: `modal_controller.js` の `close()` でエラー要素を削除

### 6. 編集モーダル：閉じてもエラーメッセージが残る
- **原因**: 同上
- **修正**: `edit_modal_controller.js` の `close()` でエラー要素を削除

### 7. 編集モーダル：閉じると持ち物名が空欄になる
- **原因**: バリデーションエラー後のTurbo Stream replaceで空の値が残り、モーダルを閉じても復元されなかった
- **修正**: `_item.html.erb` にdata属性で元の名前を保持し、`close()` 時にinputの値を復元

## 確認環境
- ローカル
- 本番（Render）：デプロイ後に確認予定

Closes #23