### PR TITLE
add:利用規約とプライバシーポリシーの設置

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[ top terms privacy ]
+  skip_before_action :authenticate_user!, only: %i[top terms privacy]
   
   def top; end
   def terms; end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,7 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:top]
+  skip_before_action :authenticate_user!, only: %i[ top terms privacy ]
   
   def top; end
+  def terms; end
+  def privacy; end
 end

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,76 @@
+<div class="min-h-screen bg-cream px-10 py-16">
+  <div style="max-width: 672px; margin: 0 auto; padding: 0 40px;">
+
+    <h1 class="font-nunito text-3xl font-black text-brown mb-2">プライバシーポリシー</h1>
+    <p class="font-dm text-xs text-text-muted mb-10">最終更新日：2026年5月16日</p>
+
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">1. 収集する情報</h2>
+        <ul class="font-dm text-sm text-text-main leading-relaxed list-disc list-inside flex flex-col gap-1">
+          <li>メールアドレス・パスワード（メール登録の場合）</li>
+          <li>LINEユーザーID・表示名（LINEログイン利用時）</li>
+          <li>パッキングリスト・持ち物データ（入力コンテンツ）</li>
+          <li>アクセスログ・Cookie情報（自動収集）</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">2. 利用目的</h2>
+        <ul class="font-dm text-sm text-text-main leading-relaxed list-disc list-inside flex flex-col gap-1">
+          <li>本サービスの提供・運営・改善</li>
+          <li>ユーザー認証・アカウント管理</li>
+          <li>LINE通知の送信（LINEログインユーザーかつ通知設定ONの場合）</li>
+          <li>アクセス解析（Googleアナリティクス）</li>
+          <li>不正利用の検知・防止</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">3. Googleアナリティクス</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed mb-2">
+          本サービスはGoogleアナリティクスを使用しています。<br>
+          Cookieを通じて匿名のアクセス情報を収集・分析します。<br>
+          個人を特定する情報は収集しません。<br>
+          無効化を希望する場合は<%= link_to "こちら", "https://tools.google.com/dlpage/gaoptout", target: "_blank", class: "text-gold underline" %>からオプトアウトできます。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">4. 第三者提供</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          法令に基づく場合を除き、収集した個人情報を第三者に提供しません。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">5. 外部サービスの利用</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          本サービスは、ホスティング・データベース・認証・アクセス解析等の目的で外部サービスを利用しています。<br>
+          これらのサービスにおける個人情報の取り扱いは、各サービスのプライバシーポリシーに従います。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">6. 開示・削除の請求</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          ご自身の個人情報の開示・訂正・削除を希望する場合や、本ポリシーに関するお問い合わせは、お問い合わせフォームよりご連絡ください。<br>
+          <%= link_to "お問い合わせフォームはこちら", "https://docs.google.com/forms/d/e/1FAIpQLScS_5MxAzhzmDVwqyVxMTrLXlsf2tpeqjGmpajnB_ymbPy2fw/viewform?usp=publish-editor", target: "_blank", class: "text-gold underline" %>
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">7. ポリシーの変更</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          本ポリシーは予告なく変更することがあります。<br>
+          変更後も継続して利用した場合、変更後のポリシーに同意したものとみなします。
+        </p>
+      </section>
+
+    </div>
+
+    <p class="font-dm text-xs text-text-muted mt-12">以上</p>
+
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,80 @@
+<div class="min-h-screen bg-cream px-10 py-16">
+  <div style="max-width: 672px; margin: 0 auto; padding: 0 40px;">
+
+    <h1 class="font-nunito text-3xl font-black text-brown mb-2">利用規約</h1>
+    <p class="font-dm text-xs text-text-muted mb-10">最終更新日：2026年5月16日</p>
+
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">1. 適用</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          本規約は、PackReady（以下「本サービス」）の利用に関する条件を定めます。<br>
+          利用登録をもって本規約に同意したものとみなします。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">2. アカウント管理</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          アカウント情報はご自身の責任で管理してください。<br>
+          第三者への譲渡・貸与は禁止です。<br>
+          管理不十分により生じた損害について運営者は責任を負いません。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">3. 禁止事項</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed mb-2">以下の行為を禁止します。</p>
+        <ul class="font-dm text-sm text-text-main leading-relaxed list-disc list-inside flex flex-col gap-1">
+          <li>法令・公序良俗に違反する行為</li>
+          <li>本サービスの運営を妨害する行為</li>
+          <li>不正アクセス・なりすまし行為</li>
+          <li>その他、運営者が不適切と判断する行為</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">4. サービスの変更・停止</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          運営者は、事前通知なくサービスの内容変更・停止・廃止を行うことがあります。<br>
+          これによりユーザーに生じた損害について、運営者は責任を負いません。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">5. 免責事項</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          本サービスは現状有姿で提供します。<br>
+          運営者の故意または重大な過失による場合を除き、本サービスに起因する損害について責任を負いません。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">6. 個人情報</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          個人情報の取り扱いは、別途定めるプライバシーポリシーに従います。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">7. 規約の変更</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          本規約は予告なく変更することがあります。<br>
+          変更後も継続して利用した場合、変更後の規約に同意したものとみなします。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="font-nunito text-base font-bold text-brown mb-2">8. 準拠法・管轄</h2>
+        <p class="font-dm text-sm text-text-main leading-relaxed">
+          本規約は日本法に準拠し、紛争が生じた場合は運営者所在地を管轄する裁判所を専属的合意管轄とします。
+        </p>
+      </section>
+
+    </div>
+
+    <p class="font-dm text-xs text-text-muted mt-12">以上</p>
+
+  </div>
+</div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -33,8 +33,8 @@
 
   <%# フッターリンク %>
   <div class="flex gap-6">
-    <%= link_to "プライバシーポリシー", "#", class: "font-dm text-xs text-text-muted opacity-45" %>
-    <%= link_to "利用規約",             "#", class: "font-dm text-xs text-text-muted opacity-45" %>
+    <%= link_to "プライバシーポリシー", privacy_path, class: "font-dm text-xs text-text-muted opacity-45" %>
+    <%= link_to "利用規約", terms_path, class: "font-dm text-xs text-text-muted opacity-45" %>
   </div>
 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
   # トップURL(/)にアクセスしたとき、StaticPagesControllerのtopアクションが実行される
   root "static_pages#top"
 
+  # 利用規約・プライバシーポリシー
+  get "/terms" => "static_pages#terms", as: :terms
+  get "/privacy" => "static_pages#privacy", as: :privacy
+
   # パッキングリストのルーティング
   resources :packing_lists, only: %i[ index new create show edit update destroy ] do
     # itemsは必ずpacking_listsに属するためネスト


### PR DESCRIPTION
## 概要
利用規約とプライバシーポリシーのページを設置

## 実装内容
- 利用規約ページ作成
- プライバシーポリシーページ作成
- Googleフォームによるお問い合わせリンク設置
- トップページフッターにリンク設置

closes #72 